### PR TITLE
Use the internal service for the Harbor API

### DIFF
--- a/ci/test/deploy.yaml
+++ b/ci/test/deploy.yaml
@@ -12,7 +12,6 @@ spec:
       username: ((harbor.harbor_username))
       password: ((harbor.harbor_password))
       harbor:
-        url: ((harbor.harbor_url))
         prevent_vul: "false"
       notary:
         url: ((harbor.notary_url))


### PR DESCRIPTION
We (autom8) want to be able to block access from the public internet to
the Harbor API. Previously we had done this by implementing a IP
safelist. Given some changes we're expecting to make to Istio we will be
unable to see the original IP of the user at the point that our current
safelist performs its checks.

We have decided to block API access entirely (except from within the
cluster).

Our `concourse-harbor-resource` now defaults to using the internal
service to talk to the Harbor API so all we need to do is remove the
explicit setting of `harbor.url`.

See also:
https://github.com/alphagov/verify-metadata-controller/pull/53
Commit 6522acb3c1bebbfccb8fb4442086ef88d218dad7 in this repository